### PR TITLE
api-ms-win-core-localization-l1-2-1: use WINAPI define to determine calling convention

### DIFF
--- a/libraries/api-ms-win-core-localization-l1-2-1/winnls.cpp
+++ b/libraries/api-ms-win-core-localization-l1-2-1/winnls.cpp
@@ -2,7 +2,7 @@
 
 #include <iostream>
 
-int __attribute__((stdcall)) LCMapStringEx(LPCWSTR lpLocaleName, DWORD dwMapFlags, LPCWSTR lpSrcStr, int cchSrc, LPWSTR lpDestStr, int cchDest, LPNLSVERSIONINFO lpVersionInformation, LPVOID lpReserved, LPARAM sortHandle) {
+int WINAPI LCMapStringEx(LPCWSTR lpLocaleName, DWORD dwMapFlags, LPCWSTR lpSrcStr, int cchSrc, LPWSTR lpDestStr, int cchDest, LPNLSVERSIONINFO lpVersionInformation, LPVOID lpReserved, LPARAM sortHandle) {
   if (lpLocaleName != LOCALE_NAME_USER_DEFAULT) {
     std::cout << "LCMapStringEx: Unimplemented Locale Name" << std::endl;
   }

--- a/libraries/api-ms-win-core-localization-l1-2-1/winnls.h
+++ b/libraries/api-ms-win-core-localization-l1-2-1/winnls.h
@@ -42,6 +42,6 @@ struct NLSVERSIONINFO {
 typedef NLSVERSIONINFO* LPNLSVERSIONINFO;
 
 extern "C" {
-  int __attribute__((stdcall)) LCMapStringEx(LPCWSTR lpLocaleName, DWORD dwMapFlags, LPCWSTR lpSrcStr, int cchSrc, LPWSTR lpDestStr, int cchDest, LPNLSVERSIONINFO lpVersionInformation, LPVOID lpReserved, LPARAM sortHandle);
+  int WINAPI LCMapStringEx(LPCWSTR lpLocaleName, DWORD dwMapFlags, LPCWSTR lpSrcStr, int cchSrc, LPWSTR lpDestStr, int cchDest, LPNLSVERSIONINFO lpVersionInformation, LPVOID lpReserved, LPARAM sortHandle);
 };
 


### PR DESCRIPTION
…alling convention